### PR TITLE
Pin to Node 12 so we're consistent across the board

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:12
 
 RUN apt-get update && \
     apt-get -y install  xvfb curl gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \


### PR DESCRIPTION
All of our Node applications are running Node 12 now, so our CI containers probably should be as well.